### PR TITLE
Updated to work against zig nightly (0.16.0-dev.2535+b5bd49460)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,7 +29,7 @@ pub fn build(b: *Build) !void {
     });
 
     // inject the cimgui header search path into the sokol C library compile step
-    dep_sokol.artifact("sokol_clib").addIncludePath(dep_cimgui.path(cimgui_conf.include_dir));
+    dep_sokol.module("mod_sokol_clib").addIncludePath(dep_cimgui.path(cimgui_conf.include_dir));
 
     // main module with sokol and cimgui imports
     const mod_main = b.createModule(.{
@@ -52,6 +52,7 @@ pub fn build(b: *Build) !void {
             .dep_sokol = dep_sokol,
             .dep_cimgui = dep_cimgui,
             .cimgui_clib_name = cimgui_conf.clib_name,
+            .cimgui_mod_clib_name = b.fmt("mod_{s}", .{cimgui_conf.clib_name}),
         });
     } else {
         try buildNative(b, mod_main);
@@ -72,6 +73,7 @@ const BuildWasmOptions = struct {
     dep_sokol: *Dependency,
     dep_cimgui: *Dependency,
     cimgui_clib_name: []const u8,
+    cimgui_mod_clib_name: []const u8,
 };
 
 fn buildWasm(b: *Build, opts: BuildWasmOptions) !void {
@@ -89,7 +91,7 @@ fn buildWasm(b: *Build, opts: BuildWasmOptions) !void {
     // the cimgui C library otherwise the C/C++ code won't find
     // C stdlib headers
     const emsdk_incl_path = dep_emsdk.path("upstream/emscripten/cache/sysroot/include");
-    opts.dep_cimgui.artifact(opts.cimgui_clib_name).addSystemIncludePath(emsdk_incl_path);
+    opts.dep_cimgui.module(opts.cimgui_mod_clib_name).addSystemIncludePath(emsdk_incl_path);
 
     // all C libraries need to depend on the sokol library, when building for
     // WASM this makes sure that the Emscripten SDK has been setup before

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,12 +4,12 @@
     .fingerprint = 0x60a713b269ae5b2,
     .dependencies = .{
         .sokol = .{
-            .url = "git+https://github.com/floooh/sokol-zig.git#aaf291ca2d3d1cedc05d65f5a1cacae0f53d934a",
-            .hash = "sokol-0.1.0-pb1HK4iDNgCom5dkY66eUBm_bYBHEl8KWFDAiqwWgpEy",
+            .url = "git+https://github.com/floooh/sokol-zig.git#baa842af7081c0d26d94847c5ecb398d8c5005cb",
+            .hash = "sokol-0.1.0-pb1HK_-oNgARi7JDvtvcu9fo8-5ArHCZ3u2bcBsFsu0y",
         },
         .cimgui = .{
-            .url = "git+https://github.com/floooh/dcimgui.git#6c2c7f0452d9f44c95094c3f7dc2969c2c6a5e1a",
-            .hash = "cimgui-0.1.0-44ClkQYjlQCl0iQX5wlquJ-mFZMqSxXA3hE2MG_3i1BT",
+            .url = "git+https://github.com/floooh/dcimgui.git#4bc7f9147073585b46e81ec750bffda2eb6d6832",
+            .hash = "cimgui-0.1.0-44ClkdQjlQDAxGXHT035QPGsTEex3c7VXeDkqJG8eUqO",
         },
     },
     .paths = .{""},

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,6 @@
 const use_docking = @import("build_options").docking;
 const ig = if (use_docking) @import("cimgui_docking") else @import("cimgui");
+const std = @import("std");
 const sokol = @import("sokol");
 const slog = sokol.log;
 const sg = sokol.gfx;
@@ -58,19 +59,34 @@ export fn frame() void {
         .DUMMY => "Dummy",
     };
 
+    var buffer: [128:0]u8 = undefined;
+
     //=== UI CODE STARTS HERE
     ig.igSetNextWindowPos(.{ .x = 10, .y = 30 }, ig.ImGuiCond_Once);
     ig.igSetNextWindowSize(.{ .x = 400, .y = 100 }, ig.ImGuiCond_Once);
     if (ig.igBegin("Hello Dear ImGui!", &state.show_first_window, ig.ImGuiWindowFlags_None)) {
         _ = ig.igColorEdit3("Background", &state.pass_action.colors[0].clear_value.r, ig.ImGuiColorEditFlags_None);
-        _ = ig.igText("Dear ImGui Version: %s", ig.IMGUI_VERSION);
+
+        // Use this with zig 0.16+, which is currently in development
+        // _ = std.fmt.bufPrintSentinel(&buffer, "Dear ImGui Version: {s}", .{ig.IMGUI_VERSION}, 0) catch @panic("OOM");
+
+        // Use this with zig 0.15.2, which is currently the stable release
+        _ = std.fmt.bufPrintZ(&buffer, "Dear ImGui Version: {s}", .{ig.IMGUI_VERSION}) catch @panic("OOM");
+
+        ig.igTextEx(&buffer);
     }
     ig.igEnd();
 
     ig.igSetNextWindowPos(.{ .x = 50, .y = 150 }, ig.ImGuiCond_Once);
     ig.igSetNextWindowSize(.{ .x = 400, .y = 100 }, ig.ImGuiCond_Once);
     if (ig.igBegin("Another Window", &state.show_second_window, ig.ImGuiWindowFlags_None)) {
-        _ = ig.igText("Sokol Backend: %s", backendName);
+        // Use this with zig 0.16+, which is currently in development
+        // _ = std.fmt.bufPrintSentinel(&buffer, "Sokol Backend: {s}", .{backendName}, 0) catch @panic("OOM");
+
+        // Use this with zig 0.15.2, which is currently the stable release
+        _ = std.fmt.bufPrintZ(&buffer, "Sokol Backend: {s}", .{backendName}) catch @panic("OOM");
+
+        ig.igTextEx(&buffer);
     }
     ig.igEnd();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -73,7 +73,7 @@ export fn frame() void {
         // Use this with zig 0.15.2, which is currently the stable release
         _ = std.fmt.bufPrintZ(&buffer, "Dear ImGui Version: {s}", .{ig.IMGUI_VERSION}) catch @panic("OOM");
 
-        ig.igTextEx(&buffer);
+        ig.igTextUnformatted(&buffer);
     }
     ig.igEnd();
 
@@ -86,7 +86,7 @@ export fn frame() void {
         // Use this with zig 0.15.2, which is currently the stable release
         _ = std.fmt.bufPrintZ(&buffer, "Sokol Backend: {s}", .{backendName}) catch @panic("OOM");
 
-        ig.igTextEx(&buffer);
+        ig.igTextUnformatted(&buffer);
     }
     ig.igEnd();
 


### PR DESCRIPTION
    * Updated dependencies
    * Validated this works on windows 11 with/without docking, and for both
      desktop and wasm targets