### PR TITLE
workaround zig 0.16 Threaded.zig compile failure on wasm32-emscripten

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,5 +20,5 @@ jobs:
             sudo apt-get install libglu1-mesa-dev mesa-common-dev xorg-dev libasound-dev
       - name: build-native
         run: zig build --summary all
-      #- name: build-web
-      #  run: zig build --summary all -Dtarget=wasm32-emscripten
+      - name: build-web
+        run: zig build --summary all -Dtarget=wasm32-emscripten

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,6 +8,14 @@ const sglue = sokol.glue;
 const simgui = sokol.imgui;
 const sgimgui = sokol.sgimgui;
 
+const std = @import("std");
+pub const panic = std.debug.FullPanic(wasmPanic);
+fn wasmPanic(msg: []const u8, ret_addr: ?usize) noreturn {
+    _ = msg;
+    _ = ret_addr;
+    @trap();
+}
+
 const state = struct {
     var pass_action: sg.PassAction = .{};
     var show_first_window: bool = true;


### PR DESCRIPTION
`std.Io.Threaded` pulled into `wasm32-emscripten` builds via `defaultPanic`

Building any Zig program targeting `wasm32-emscripten` with Zig 0.16 fails with:

```
std/Io/Threaded.zig:15315:38: error: expected type 'os.linux.SIG__enum_XXXX', found 'u32'
std/os/emscripten.zig:215:16: error: expected enum, found 'u32'
```

Override the panic handler in the main :

```zig
const std = @import("std");
pub const panic = std.debug.FullPanic(wasmPanic);
fn wasmPanic(msg: []const u8, ret_addr: ?usize) noreturn {
    _ = msg; _ = ret_addr;
    @trap();
}
```